### PR TITLE
Update experience section with shorter text and proper links

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -77,13 +77,13 @@ const HomePage = () => {
   const experiences = [
     {
       name: 'Research Assistant',
-      org: 'SCSU - Avatar BCI',
-      url: '#'
+      org: 'Avatar BCI',
+      url: 'https://github.com/3C-SCSU'
     },
     {
       name: 'Administrative Support Assistant',
-      org: 'SCSU',
-      url: '#'
+      org: 'CIS, SGS',
+      url: 'https://www.stcloudstate.edu/internationalstudies/'
     },
   ];
 


### PR DESCRIPTION
## Changes
- Shorten Research Assistant organization from "SCSU - Avatar BCI" to "Avatar BCI"
- Update Administrative Support Assistant from "SCSU" to "CIS, SGS"
- Add proper link to Avatar BCI GitHub repository: https://github.com/3C-SCSU
- Add proper link to CIS website: https://www.stcloudstate.edu/internationalstudies/

## Display
The experience section now shows:
- "Research Assistant - Avatar BCI" (links to Avatar BCI GitHub)
- "Administrative Support Assistant - CIS, SGS" (links to CIS website)

This provides a cleaner, more concise display while maintaining the hover-reveal functionality.