### PR TITLE
Improve gradient hints and fun side text (Issue #12)

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -169,10 +169,20 @@ const HomePage = () => {
     >
       {/* Edge gradient hints */}
       {personality === 'professional' && (
-        <div className="fixed top-0 right-0 h-full w-32 bg-gradient-to-l from-orange-500/20 to-transparent pointer-events-none" />
+        <div
+          className="fixed top-0 right-0 h-full w-32 pointer-events-none"
+          style={{
+            background: 'linear-gradient(to left, rgba(255, 87, 34, 0.6), rgba(255, 87, 34, 0.4), rgba(255, 87, 34, 0.2), rgba(255, 87, 34, 0.08), transparent)'
+          }}
+        />
       )}
       {personality === 'fun' && (
-        <div className="fixed top-0 left-0 h-full w-32 bg-gradient-to-r from-white/20 to-transparent pointer-events-none" />
+        <div
+          className="fixed top-0 left-0 h-full w-32 pointer-events-none"
+          style={{
+            background: 'linear-gradient(to right, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.08), transparent)'
+          }}
+        />
       )}
 
       <div className="max-w-7xl w-full relative z-10">
@@ -411,10 +421,7 @@ const HomePage = () => {
 
               <div className="space-y-10 mb-8">
                 <p className="text-2xl md:text-3xl lg:text-4xl leading-relaxed max-w-4xl font-light">
-                  I&apos;M ARSALAN. I LIKE PLAYING GAMES AND WATCH ANIME.
-                </p>
-                <p className="text-2xl md:text-3xl lg:text-4xl leading-relaxed max-w-4xl font-light">
-                  I LOVE EXPLORING NEW WORLDS IN GAMES AND BINGE WATCHING MY FAVORITE SHOWS.
+                  I&apos;M ARSALAN. I BUILD STUFF BY DAY AND EXPLORE DIGITAL WORLDS BY NIGHT.
                 </p>
               </div>
 


### PR DESCRIPTION
## Summary
Fixes #12 by improving edge gradient visibility and updating the fun side intro text.

## Changes Made

### 1. Enhanced Edge Gradient Hints
- **Before**: Simple 2-step gradients with 20% opacity (too subtle)
- **After**: Smooth 5-step gradients with 60% max opacity for better visibility
- **Orange gradient (professional side)**: `60% → 40% → 20% → 8% → transparent`
- **White gradient (fun side)**: `60% → 40% → 20% → 8% → transparent`
- **Result**: Gradients are now clearly visible while maintaining a smooth, elegant blend

### 2. Updated Fun Side Text
- **Before**: Two paragraphs about playing games and watching anime
- **After**: Single concise line: "I'M ARSALAN. I BUILD STUFF BY DAY AND EXPLORE DIGITAL WORLDS BY NIGHT."
- **Result**: More engaging, concise, and better represents the dual nature of the portfolio

## Technical Details
- Used inline CSS `linear-gradient()` with multiple color stops for smoother transitions
- Maintained `w-32` (128px) width for gradient hints
- Preserved all existing functionality and responsive behavior
- Kept proper HTML entities for apostrophes

## Testing
Tested on:
- Desktop browsers: Smooth gradient blending verified
- Both personalities: Orange on professional, white on fun side
- Text rendering: Single paragraph displays correctly
- Responsive sizing: Text scales properly on mobile/tablet/desktop
- No regressions: All hover interactions and transitions work correctly

Closes #12